### PR TITLE
refs #5 support Django-1.10

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,3 +4,4 @@ unreleased
 - #2 add test cases
 - #3 remove some extra features for first release
 - #4 remove commented out codes
+- #5 support Django-1.10

--- a/beproud/django/basemodels/fields.py
+++ b/beproud/django/basemodels/fields.py
@@ -117,7 +117,6 @@ class PositiveBigIntegerField(BigIntegerField):
 
 
 class PickledObjectField(models.TextField):
-    __metaclass__ = models.SubfieldBase
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
@@ -126,11 +125,10 @@ class PickledObjectField(models.TextField):
 
         super(PickledObjectField, self).__init__(*args, **kwargs)
 
-    def to_python(self, value):
+    def from_db_value(self, value, expression, connection, context):
         if value is None:
             return None
-        if not isinstance(value, basestring):
-            return value
+
         return pickle.loads(base64.b64decode(value))
 
     def get_db_prep_save(self, value, connection=None):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -198,6 +198,24 @@ class TestPickledObjectField(object):
         from beproud.django.basemodels.fields import PickledObjectField
         return PickledObjectField
 
+    @pytest.fixture
+    def model_cls(self):
+        from test_project.models import DummyPickleFieldModel
+        return DummyPickleFieldModel
+
+    def test_it(self, model_cls):
+        # setup
+        object_ = {'a': [1, 2, 3], 'b': ('AAA', 'BBB'), 'c': None}
+
+        # act
+        instance = model_cls.objects.create(
+            pickled_object=object_,
+        )
+        gotten = model_cls.objects.get(pk=instance.pk)
+
+        # assert
+        assert gotten.pickled_object == object_
+
     @pytest.mark.parametrize(
         'value,expected',
         (
@@ -219,16 +237,15 @@ class TestPickledObjectField(object):
         'value,expected',
         (
             (None, None),
-            ([], []),
             ('UydhYWEnCnAxCi4=', 'aaa'),
         )
     )
-    def test_to_python(self, value, expected, target):
+    def test_from_db_value(self, value, expected, target):
         # arrange
         field = target()
 
         # act
-        actual = field.to_python(value)
+        actual = field.from_db_value(value, None, None, None)
 
         # assert
         assert actual == expected

--- a/tests/test_project/migrations/0001_initial.py
+++ b/tests/test_project/migrations/0001_initial.py
@@ -69,4 +69,11 @@ class Migration(migrations.Migration):
                 ('non_int', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='test_project.DummyNonIntegerPKModel')),
             ],
         ),
+        migrations.CreateModel(
+            name='DummyPickleFieldModel',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('pickled_object', beproud.django.basemodels.fields.PickledObjectField()),
+            ],
+        ),
     ]

--- a/tests/test_project/models.py
+++ b/tests/test_project/models.py
@@ -64,3 +64,10 @@ class DummyChildModel(models.Model):
 
     class Meta:
         app_label = 'test_project'
+
+
+class DummyPickleFieldModel(models.Model):
+    pickled_object = fields.PickledObjectField(DummyBaseModel)
+
+    class Meta:
+        app_label = 'test_project'

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py27-django{18,19},flake8
+envlist = py27-django{18,19,110},flake8
 
 [testenv]
 deps =
     django18:  Django>=1.8,<1.9
     django19:  Django>=1.9,<1.10
+    django110:  Django>=1.10,<1.11
     -rrequirements.txt
 changedir = {toxinidir}/tests
 setenv =


### PR DESCRIPTION
**note:** before merge this branch, merge PR #2 

support django 1.10
- replace a metaclass called SubfieldBase and `to_python()` with `from_db_value()`
  - https://docs.djangoproject.com/en/1.9/howto/custom-model-fields/#converting-values-to-python-objects
